### PR TITLE
Add discount and tax calculations to sales form

### DIFF
--- a/src/DAO/ItensVendidosDAO.java
+++ b/src/DAO/ItensVendidosDAO.java
@@ -8,7 +8,7 @@ import javax.swing.JOptionPane;
 
 public class ItensVendidosDAO {
     public void salvar(ItensVendidosDTO dto) throws ClassNotFoundException {
-        String sql = "INSERT INTO itens_vendidos (tipo_produto, nome_produto, marca, quantidade, preco_unitario, subtotal) VALUES (?, ?, ?, ?, ?, ?)";
+        String sql = "INSERT INTO itens_vendidos (tipo_produto, nome_produto, marca, quantidade, preco_unitario, subtotal, desconto, imposto, total) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
         Connection conn = new ConexaoDAO().conectaBD();
 
         try (PreparedStatement pstm = conn.prepareStatement(sql)) {
@@ -18,6 +18,9 @@ public class ItensVendidosDAO {
             pstm.setInt(4, dto.getQuantidadeVendida());
             pstm.setDouble(5, dto.getPrecoUnitario());
             pstm.setDouble(6, dto.getSubtotalVenda());
+            pstm.setDouble(7, dto.getDesconto());
+            pstm.setDouble(8, dto.getImposto());
+            pstm.setDouble(9, dto.getTotal());
 
             pstm.executeUpdate();
             JOptionPane.showMessageDialog(null, "Cadastro realizado com sucesso!");

--- a/src/DTO/ItensVendidosDTO.java
+++ b/src/DTO/ItensVendidosDTO.java
@@ -7,6 +7,9 @@ public class ItensVendidosDTO {
     private int quantidadeVendida;
     private double precoUnitario;
     private double subtotalVenda;
+    private double desconto;
+    private double imposto;
+    private double total;
 
     // Getters e Setters
     public String getTipoProduto() {
@@ -55,5 +58,29 @@ public class ItensVendidosDTO {
 
     public void setSubtotalVenda(double subtotalVenda) {
         this.subtotalVenda = subtotalVenda;
+    }
+
+    public double getDesconto() {
+        return desconto;
+    }
+
+    public void setDesconto(double desconto) {
+        this.desconto = desconto;
+    }
+
+    public double getImposto() {
+        return imposto;
+    }
+
+    public void setImposto(double imposto) {
+        this.imposto = imposto;
+    }
+
+    public double getTotal() {
+        return total;
+    }
+
+    public void setTotal(double total) {
+        this.total = total;
     }
 }

--- a/src/VIEW/frmCadastroDeItensVendidos.java
+++ b/src/VIEW/frmCadastroDeItensVendidos.java
@@ -41,7 +41,13 @@ public class frmCadastroDeItensVendidos extends javax.swing.JFrame {
         precoUnitVendatxt = new javax.swing.JTextField();
         jLabel7 = new javax.swing.JLabel();
         jLabel5 = new javax.swing.JLabel();
+        jLabel8 = new javax.swing.JLabel();
+        jLabel9 = new javax.swing.JLabel();
+        jLabel10 = new javax.swing.JLabel();
         subtotVendastxt = new javax.swing.JTextField();
+        descontotxt = new javax.swing.JTextField();
+        impostotxt = new javax.swing.JTextField();
+        totalVendastxt = new javax.swing.JTextField();
         jLabel1 = new javax.swing.JLabel();
 
         setDefaultCloseOperation(javax.swing.WindowConstants.EXIT_ON_CLOSE);
@@ -71,6 +77,15 @@ public class frmCadastroDeItensVendidos extends javax.swing.JFrame {
         jLabel5.setFont(new java.awt.Font("Segoe UI", 1, 14)); // NOI18N
         jLabel5.setText("Subtotal de vendas");
 
+        jLabel8.setFont(new java.awt.Font("Segoe UI", 1, 14)); // NOI18N
+        jLabel8.setText("Desconto (%)");
+
+        jLabel9.setFont(new java.awt.Font("Segoe UI", 1, 14)); // NOI18N
+        jLabel9.setText("Imposto (%)");
+
+        jLabel10.setFont(new java.awt.Font("Segoe UI", 1, 14)); // NOI18N
+        jLabel10.setText("Total de vendas");
+
         subtotVendastxt.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 subtotVendastxtActionPerformed(evt);
@@ -88,11 +103,17 @@ public class frmCadastroDeItensVendidos extends javax.swing.JFrame {
             .addGroup(jPanel1Layout.createSequentialGroup()
                 .addContainerGap(51, Short.MAX_VALUE)
                 .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(subtotVendastxt, javax.swing.GroupLayout.PREFERRED_SIZE, 360, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(jLabel5)
+                    .addComponent(qtdetxt, javax.swing.GroupLayout.PREFERRED_SIZE, 360, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(jLabel7)
                     .addComponent(precoUnitVendatxt, javax.swing.GroupLayout.PREFERRED_SIZE, 360, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(qtdetxt, javax.swing.GroupLayout.PREFERRED_SIZE, 360, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel5)
+                    .addComponent(subtotVendastxt, javax.swing.GroupLayout.PREFERRED_SIZE, 360, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel8)
+                    .addComponent(descontotxt, javax.swing.GroupLayout.PREFERRED_SIZE, 360, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel9)
+                    .addComponent(impostotxt, javax.swing.GroupLayout.PREFERRED_SIZE, 360, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel10)
+                    .addComponent(totalVendastxt, javax.swing.GroupLayout.PREFERRED_SIZE, 360, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(jLabel6)
                     .addComponent(jLabel4)
                     .addComponent(marcatxt, javax.swing.GroupLayout.PREFERRED_SIZE, 360, javax.swing.GroupLayout.PREFERRED_SIZE)
@@ -138,6 +159,18 @@ public class frmCadastroDeItensVendidos extends javax.swing.JFrame {
                 .addComponent(jLabel5)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addComponent(subtotVendastxt, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addComponent(jLabel8)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addComponent(descontotxt, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addComponent(jLabel9)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addComponent(impostotxt, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addComponent(jLabel10)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addComponent(totalVendastxt, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(btnCadastrar)
                 .addContainerGap(13, Short.MAX_VALUE))
@@ -154,6 +187,12 @@ public class frmCadastroDeItensVendidos extends javax.swing.JFrame {
             double preco = Double.parseDouble(precoUnitVendatxt.getText());
             double subtotal = quantidade * preco;
             subtotVendastxt.setText(String.valueOf(subtotal));
+
+            double descontoPerc = Double.parseDouble(descontotxt.getText());
+            double impostoPerc = Double.parseDouble(impostotxt.getText());
+            double valorComDesconto = subtotal - (subtotal * descontoPerc / 100);
+            double total = valorComDesconto + (valorComDesconto * impostoPerc / 100);
+            totalVendastxt.setText(String.valueOf(total));
         } catch (NumberFormatException ex) {
             logger.log(java.util.logging.Level.SEVERE, null, ex);
         }
@@ -192,6 +231,9 @@ public class frmCadastroDeItensVendidos extends javax.swing.JFrame {
     private javax.swing.JLabel jLabel3;
     private javax.swing.JLabel jLabel4;
     private javax.swing.JLabel jLabel5;
+    private javax.swing.JLabel jLabel8;
+    private javax.swing.JLabel jLabel9;
+    private javax.swing.JLabel jLabel10;
     private javax.swing.JLabel jLabel6;
     private javax.swing.JLabel jLabel7;
     private javax.swing.JPanel jPanel1;
@@ -200,5 +242,8 @@ public class frmCadastroDeItensVendidos extends javax.swing.JFrame {
     private javax.swing.JTextField precoUnitVendatxt;
     private javax.swing.JTextField qtdetxt;
     private javax.swing.JTextField subtotVendastxt;
+    private javax.swing.JTextField descontotxt;
+    private javax.swing.JTextField impostotxt;
+    private javax.swing.JTextField totalVendastxt;
     // End of variables declaration//GEN-END:variables
 }


### PR DESCRIPTION
## Summary
- add discount, tax and total fields to sales form
- compute total value considering discount and tax
- extend `ItensVendidosDTO` with new fields and accessors
- persist new values in `ItensVendidosDAO`

## Testing
- `javac @sources.txt` *(fails: package org.netbeans.lib.awtextra does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_686746f682808326b29ed76f0a3de498